### PR TITLE
Set Elasticsearch discovery.type in ghe-logging docker-compose.yml

### DIFF
--- a/ghe-logging/docker-compose.yml
+++ b/ghe-logging/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     volumes:
       - es_data:/usr/share/elasticsearch/data
     environment:
+      - discovery.type=single-node
       - http.host=0.0.0.0
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
     ulimits:


### PR DESCRIPTION
fixes #46 

- - - - 
This change is the first thing I tried after I compared the ghe-logging docker-compose.yml to a Docker Compose stack I'd written to run Graylog 4.2. That is: I'm not emotionally attached to this change at all.

If you prefer a different mitigation, or if this change is unnecessary (and the error in #46 should be prevented a different way), please lmk, I'm happy to learn :bow: